### PR TITLE
Fix markdown for mermaid diagram in Architecture.md

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -62,7 +62,7 @@ and persists everything to a MySQL database.
  
 > Breaks down ElectroView into its deployable containers and their interactions.
  
-``mermaid
+```mermaid
 graph TB
     subgraph client["Client Layer"]
         swagger["Swagger UI<br/>(API documentation & testing)"]


### PR DESCRIPTION
Corrected markdown syntax for mermaid code block.