### PR TITLE
fix: expand Meter.toString() to include zoneId and consumerId

### DIFF
--- a/electroview/src/main/java/za/ac/cput/domain/Meter.java
+++ b/electroview/src/main/java/za/ac/cput/domain/Meter.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-@ToString
+@ToString(of = {"meterId", "serialNumber", "status", "zoneId", "consumerId"})
 public class Meter {
 
     @Id


### PR DESCRIPTION
Closes #22

The previous `@ToString` with no parameters included all fields, including the
`readings` collection — which is noisy, can trigger lazy-loading issues, and
makes log output hard to read. Pinning the output to the five key identity/state
fields gives clean, predictable debug strings.